### PR TITLE
fix: update timestampt behavior for big and negative numbers

### DIFF
--- a/timestampt-utils.test.ts
+++ b/timestampt-utils.test.ts
@@ -1,0 +1,33 @@
+import {formatTimestamp} from "./timestampt-utils";
+
+describe('formatTimestamp', () => {
+	it('should format the timestamp correctly when hours are present', () => {
+		const timestamp = 3661000;
+		const formatted = formatTimestamp(timestamp);
+		expect(formatted).toEqual('01:01:01');
+	});
+
+	it('should format the timestamp correctly when hours are absent', () => {
+		const timestamp = 61000;
+		const formatted = formatTimestamp(timestamp);
+		expect(formatted).toEqual('01:01');
+	});
+
+	it('should format the timestamp correctly when minutes and seconds are zero', () => {
+		const timestamp = 3600000;
+		const formatted = formatTimestamp(timestamp);
+		expect(formatted).toEqual('01:00:00');
+	});
+
+	it('should format the timestamp correctly when all components are zero', () => {
+		const timestamp = 0;
+		const formatted = formatTimestamp(timestamp);
+		expect(formatted).toEqual('00:00');
+	});
+
+	it('should format the timestamp correctly when the input is negative', () => {
+		const timestamp = -5000;
+		const formatted = formatTimestamp(timestamp);
+		expect(formatted).toEqual('00:00');
+	});
+});

--- a/timestampt-utils.ts
+++ b/timestampt-utils.ts
@@ -1,0 +1,12 @@
+export const formatTimestamp = (t: number): string => {
+	if(t<0) return '00:00';
+	const fnum = (n: number):string => `${n|0}`.padStart(2,'0');
+	const s = 1000;
+	const m = 60 * s;
+	const h = 60 * m;
+	const hours = Math.floor(t / h);
+	const minutes = Math.floor((t - hours * h) / m);
+	const seconds = Math.floor((t - hours * h - minutes * m) / s);
+	const time = hours ? [hours, minutes, seconds] : [minutes, seconds];
+	return time.map(fnum).join(':')
+}

--- a/transcript-view.ts
+++ b/transcript-view.ts
@@ -1,19 +1,9 @@
 import YTranscriptPlugin from "main";
 import { ItemView, WorkspaceLeaf, Menu } from "obsidian";
 import YoutubeTranscript, { TranscriptResponse } from "youtube-transcript";
+import {formatTimestamp} from "./timestampt-utils";
 
 export const TRANSCRIPT_TYPE_VIEW = "transcript-view";
-const formatTimestamp = (t: number): string => {
-	const fnum = (n: number) => (n && n < 10) ? "0" + n.toFixed() : n.toFixed();
-	const s = 1000;
-	const m = 60 * s;
-	const h = 60 * m;
-	const hours = Math.floor(t / h);
-	const minutes = Math.floor((t - hours * h) / m);
-	const seconds = Math.floor((t - minutes * m) / s);
-	const time = hours ? [hours, minutes, seconds] : [minutes, seconds];
-	return time.map(fnum).join(':')
-}
 export class TranscriptView extends ItemView {
 	plugin: YTranscriptPlugin;
 	dataLoaded: boolean;


### PR DESCRIPTION
Hi!
I use your plugin with long videos and have an issue in timestampt label;

* in zero point we have `0:0` instead of `00:00`
* after 1 hour of video we have `01:01:3609` instead of `01:01:09`

I wrote some simple tests and fix the issue.