### PR TITLE
fix: add support for youtu.be links

### DIFF
--- a/src/fetch-transcript.ts
+++ b/src/fetch-transcript.ts
@@ -83,6 +83,7 @@ export class YoutubeTranscript {
 				}
 			}
 		} catch (err: any) {
+			console.log(err);
 			throw new YoutubeTranscriptError(err);
 		}
 	}
@@ -97,9 +98,14 @@ export class YoutubeTranscript {
 			?.split('"')[0];
 		const visitorData = page.split('"VISITOR_DATA":"')[1]?.split('"')[0];
 		const sessionId = page.split('"sessionId":"')[1]?.split('"')[0];
-		const clickTrackingParams = page
+		let clickTrackingParams = page
 			?.split('"clickTrackingParams":"')[1]
 			?.split('"')[0];
+
+		//youtu.be links have extra characters in clickTrackingParams that are not supported
+		//with the youtubei api
+		clickTrackingParams = clickTrackingParams.slice(0, 28);
+		console.log(clickTrackingParams);
 		return {
 			context: {
 				client: {
@@ -129,7 +135,7 @@ export class YoutubeTranscript {
 				user: {},
 				clientScreenNonce: this.generateNonce(),
 				clickTracking: {
-					clickTrackingParams,
+					clickTrackingParams: decodeURI(clickTrackingParams),
 				},
 			},
 			params,

--- a/src/fetch-transcript.ts
+++ b/src/fetch-transcript.ts
@@ -83,7 +83,6 @@ export class YoutubeTranscript {
 				}
 			}
 		} catch (err: any) {
-			console.log(err);
 			throw new YoutubeTranscriptError(err);
 		}
 	}
@@ -105,7 +104,6 @@ export class YoutubeTranscript {
 		//youtu.be links have extra characters in clickTrackingParams that are not supported
 		//with the youtubei api
 		clickTrackingParams = clickTrackingParams.slice(0, 28);
-		console.log(clickTrackingParams);
 		return {
 			context: {
 				client: {

--- a/src/transcript-view.ts
+++ b/src/transcript-view.ts
@@ -247,7 +247,6 @@ export class TranscriptView extends ItemView {
 		} catch (err: unknown) {
 			let errorMessage = "";
 			if (err instanceof YoutubeTranscriptError) {
-				console.log(err);
 				errorMessage = err.message;
 			}
 


### PR DESCRIPTION
This update will add support for `youtu.be` links. This resolves #20 

There is a significant difference in `clickTrackingParams` between regular `youtube.com` and `youtu.be` links. It appears that there's some extra binary encoding at the end. The Youtube API does not like this.

The solution is to only get the first 28 characters. This will make `clickTrackingParams` match for both URLs.

https://github.com/lstrzepek/obsidian-yt-transcript/assets/40307803/31c07c95-3a24-4d7e-9410-49932d9bdfce