### PR TITLE
Update better formatting when copy all fixes #10

### DIFF
--- a/src/transcript-view.ts
+++ b/src/transcript-view.ts
@@ -126,6 +126,21 @@ export class TranscriptView extends ItemView {
 				block.quote.toLowerCase().includes(searchValue.toLowerCase())
 			);
 
+			function formatContentToPaste() {
+				return filteredBlocks
+					.map((block) => {
+						const { quote, quoteTimeOffset } = block;
+						const href =
+							url + "&t=" + Math.floor(quoteTimeOffset / 1000);
+						const formattedBlock = `[${formatTimestamp(
+							quoteTimeOffset
+						)}](${href}) ${quote}`;
+
+						return formattedBlock;
+					})
+					.join("\n");
+			}
+
 			filteredBlocks.forEach((block) => {
 				const { quote, quoteTimeOffset } = block;
 				const blockContainerEl = createEl("div", {
@@ -161,7 +176,7 @@ export class TranscriptView extends ItemView {
 						menu.addItem((item) =>
 							item.setTitle("Copy all").onClick(() => {
 								navigator.clipboard.writeText(
-									data.lines.map((t) => t.text).join(" ")
+									formatContentToPaste()
 								);
 							})
 						);


### PR DESCRIPTION
Resolves issue #10 Keep formatting in 'Copy all' option

a function to copy the text displayed in the side pane as is and links to the timestamps